### PR TITLE
Added JobManager to save and access job between scenes

### DIFF
--- a/Assets/Prefabs/Jobs/JobNote.prefab
+++ b/Assets/Prefabs/Jobs/JobNote.prefab
@@ -158,3 +158,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c715120c6e37814c888433233fdc645, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  job:
+    forGang: 
+    jobType: 0
+    reward: 0
+    clothes: 

--- a/Assets/Scenes/JobBoardScene.unity
+++ b/Assets/Scenes/JobBoardScene.unity
@@ -217,6 +217,7 @@ MonoBehaviour:
   panel: {fileID: 248096534}
   titleText: {fileID: 1032703190}
   detailsText: {fileID: 425308502}
+  sceneToLoad: CleaningScene
 --- !u!1 &417698183
 GameObject:
   m_ObjectHideFlags: 0
@@ -352,7 +353,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   onClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 248096538}
+        m_TargetAssemblyTypeName: JobDetailsModal, Assembly-CSharp
+        m_MethodName: AcceptJob
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &425308500
 GameObject:
   m_ObjectHideFlags: 0
@@ -1075,6 +1088,50 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &1723279340
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1723279341}
+  - component: {fileID: 1723279342}
+  m_Layer: 0
+  m_Name: JobManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1723279341
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723279340}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.8605433, y: 2.0390325, z: -9.953403}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1723279342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723279340}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b9ced745ee03c842a7854a56891cc61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1839345903
 GameObject:
   m_ObjectHideFlags: 0
@@ -1304,3 +1361,4 @@ SceneRoots:
   - {fileID: 1863323259}
   - {fileID: 2128265269}
   - {fileID: 1524504836}
+  - {fileID: 1723279341}

--- a/Assets/Scripts/Jobs/JobDetailsModal.cs
+++ b/Assets/Scripts/Jobs/JobDetailsModal.cs
@@ -1,5 +1,5 @@
-using System.Linq;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using TMPro;
 
 public class JobDetailsModal : MonoBehaviour
@@ -9,8 +9,10 @@ public class JobDetailsModal : MonoBehaviour
     [SerializeField] private GameObject panel; // panel root to enable/disable
     [SerializeField] private TextMeshProUGUI titleText;
     [SerializeField] private TextMeshProUGUI detailsText;
+    [SerializeField] private string sceneToLoad = "CleaningScene"; // Scene to load when job is accepted
 
     private CursorManager cursorManager;
+    private Job currentJob;
 
     private void Awake()
     {
@@ -33,6 +35,7 @@ public class JobDetailsModal : MonoBehaviour
     {
         if (job == null || panel == null) return;
 
+        currentJob = job; // Store reference to current job
         panel.SetActive(true);
         titleText.text = $"Job for {job.forGang}";
         detailsText.text = $"Reward: {job.reward} gold\nItems: {job.NumberOfClothes()}";
@@ -42,5 +45,21 @@ public class JobDetailsModal : MonoBehaviour
     {
         if (panel != null) panel.SetActive(false);
         cursorManager?.SetHovering(false); // Work around for the fact that the button disappears before OnPointerExit is called
+    }
+
+    /// <summary>
+    /// Call this method when the Accept button is clicked.
+    /// It stores the current job in JobManager and loads the cleaning scene.
+    /// </summary>
+    public void AcceptJob()
+    {
+        if (currentJob == null)
+        {
+            Debug.LogWarning("No job selected to accept!");
+            return;
+        }
+
+        JobManager.SetJob(currentJob);
+        SceneManager.LoadScene(sceneToLoad);
     }
 }

--- a/Assets/Scripts/Jobs/JobManager.cs
+++ b/Assets/Scripts/Jobs/JobManager.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+
+public class JobManager : MonoBehaviour
+{
+    private static JobManager Instance = null;
+
+    private Job CurrentJob = null;
+
+    private void Awake()
+    {
+        if (Instance != null)
+        {
+            Destroy(gameObject);
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+
+    // ========== Static Convenience Methods ==========
+
+    /// <summary>
+    /// Static method to set the current job. Ensures JobManager exists.
+    /// </summary>
+    /// <param name="job">The job to store</param>
+    public static void SetJob(Job job)
+    {
+        if (Instance == null)
+        {
+            throw new System.NotSupportedException("JobManager instance does not exist in the scene. Cannot set job.");
+        }
+
+        Instance.SetCurrentJob(job);
+    }
+
+    /// <summary>
+    /// Static method to get the current job.
+    /// </summary>
+    /// <returns>The current job, or null if no job is set or JobManager doesn't exist</returns>
+    public static Job GetCurrentJob()
+    {
+        if (Instance == null)
+        {
+            throw new System.NotSupportedException("JobManager instance does not exist in the scene. Cannot get job.");
+        }
+
+        return Instance.CurrentJob;
+    }
+
+    /// <summary>
+    /// Static method to clear the current job.
+    /// </summary>
+    public static void ClearJob()
+    {
+        if (Instance == null)
+        {
+            throw new System.NotSupportedException("JobManager instance does not exist in the scene. Cannot clear job.");
+        }
+
+        Instance.ClearCurrentJob();
+    }
+
+    /// <summary>
+    /// Static method to check if a job is currently set.
+    /// </summary>
+    /// <returns>True if a job is set, false otherwise</returns>
+    public static bool HasJob()
+    {
+        return Instance != null && Instance.CurrentJob != null;
+    }
+
+    // ========== Instance Methods ==========
+
+    /// <summary>
+    /// Instance method to set the current job.
+    /// </summary>
+    /// <param name="job">The job to set as current.</param>
+    private void SetCurrentJob(Job job)
+    {
+        CurrentJob = job;
+        Debug.Log($"JobManager: Job set for {job.forGang}, reward: {job.reward} gold");
+    }
+
+    /// <summary>
+    /// Instance method to clear the current job.
+    /// </summary>
+    private void ClearCurrentJob()
+    {
+        CurrentJob = null;
+        Debug.Log("JobManager: Current job cleared");
+    }
+}

--- a/Assets/Scripts/Jobs/JobManager.cs.meta
+++ b/Assets/Scripts/Jobs/JobManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b9ced745ee03c842a7854a56891cc61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Key Features
- Can now accept job and switch scene from JobBoard.
- Saves the accepted job in the JobManager, which can be accessed to get the data across scenes.

# Known Issues
- This does not prevent the actual setting of new jobs, as I found it reasonable to be able to override it inside the code. Might be worth it to check if you have a job accepted already, and then not open the Job Board if we want to ensure such behavior.